### PR TITLE
feat: 增加题库海题库

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 - [x] icodef：[icodef 题库](https://q.icodef.com) [![免费](https://img.shields.io/badge/-免费-brightgreen)](url)
 - [x] buguake：[不挂科 题库](https://easylearn.baidu.com/edu-page/tiangong/bgklist) [![免费](https://img.shields.io/badge/-免费-brightgreen)](url) 
 - [x] wanneng：[万能题库](https://lyck6.cn/pay) [![付费](https://img.shields.io/badge/免费-付费-brightgreen?color=red&labelColor=4c1)](https://lyck6.cn/pay) 
+- [x] Tikuhai：[题库海题库](https://shop.tikuhai.com/links/2C63E8E8) [![付费](https://img.shields.io/badge/免费-付费-brightgreen?color=red&labelColor=4c1)](https://shop.tikuhai.com/links/2C63E8E8) 
 - [x] aidian：[爱点题库](https://www.51aidian.com) [![付费](https://img.shields.io/badge/-付费-red)](https://tk.enncy.cn/) 
 - [x] enncy：[enncy 言溪题库](https://tk.enncy.cn/) [![付费](https://img.shields.io/badge/-付费-red)](https://tk.enncy.cn/) 
 - [x] lemon：[柠檬题库](https://www.lemtk.xyz)[![付费](https://img.shields.io/badge/-付费-red)](https://www.lemtk.xyz) 
@@ -75,6 +76,7 @@ POST `http://localhost:8060/adapter-service/search`
 | enncyToken     | enncy 题库Token值          | 否    | a21ae2403b414b94b512736c30c69940 | https://tk.enncy.cn      |
 | aidianYToken   | 爱点题库(亿级题库API)Token值     | 否    | cvor7f3HxZ7nF2M3ljmA             | https://www.51aidian.com |
 | lemonToken     | 柠檬题库 Token值             | 否    | 8a3debe92e2ba83d6786e186bef2a424 | https://www.lemtk.xyz    |
+| tikuhaiToken | 题库海题库 Token值 | 否 | Cardabcde1MdljoZk4l4E47NaAK | https://shop.tikuhai.com/links/2C63E8E8 |
 
 例如您想使用万能题库和icodef题库，您的url应为`http://localhost:8060/adapter-service/search?use=wanneng,icodef&icodefToken=UafYcHViJMGzSVNh`
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 - [x] icodef：[icodef 题库](https://q.icodef.com) [![免费](https://img.shields.io/badge/-免费-brightgreen)](url)
 - [x] buguake：[不挂科 题库](https://easylearn.baidu.com/edu-page/tiangong/bgklist) [![免费](https://img.shields.io/badge/-免费-brightgreen)](url) 
 - [x] wanneng：[万能题库](https://lyck6.cn/pay) [![付费](https://img.shields.io/badge/免费-付费-brightgreen?color=red&labelColor=4c1)](https://lyck6.cn/pay) 
+- [x] Tikuhai：[题库海题库](https://shop.tikuhai.com/links/2C63E8E8) [![付费](https://img.shields.io/badge/免费-付费-brightgreen?color=red&labelColor=4c1)](https://lyck6.cn/pay) 
 - [x] aidian：[爱点题库](https://www.51aidian.com) [![付费](https://img.shields.io/badge/-付费-red)](https://tk.enncy.cn/) 
 - [x] enncy：[enncy 言溪题库](https://tk.enncy.cn/) [![付费](https://img.shields.io/badge/-付费-red)](https://tk.enncy.cn/) 
 - [x] lemon：[柠檬题库](https://www.lemtk.xyz)[![付费](https://img.shields.io/badge/-付费-red)](https://www.lemtk.xyz) 
@@ -75,6 +76,7 @@ POST `http://localhost:8060/adapter-service/search`
 | enncyToken     | enncy 题库Token值          | 否    | a21ae2403b414b94b512736c30c69940 | https://tk.enncy.cn      |
 | aidianYToken   | 爱点题库(亿级题库API)Token值     | 否    | cvor7f3HxZ7nF2M3ljmA             | https://www.51aidian.com |
 | lemonToken     | 柠檬题库 Token值             | 否    | 8a3debe92e2ba83d6786e186bef2a424 | https://www.lemtk.xyz    |
+| tikuhaiToken | 题库海题库 Token值 | 否 | Cardabcde1MdljoZk4l4E47NaAK | https://shop.tikuhai.com/links/2C63E8E8 |
 
 例如您想使用万能题库和icodef题库，您的url应为`http://localhost:8060/adapter-service/search?use=wanneng,icodef&icodefToken=UafYcHViJMGzSVNh`
 

--- a/internal/controller/search.go
+++ b/internal/controller/search.go
@@ -2,6 +2,10 @@ package controller
 
 import (
 	"fmt"
+	"net/http"
+	"strings"
+	"sync"
+
 	"github.com/gin-gonic/gin"
 	"github.com/itihey/tikuAdapter/internal/middleware"
 	"github.com/itihey/tikuAdapter/internal/registry/manager"
@@ -10,9 +14,6 @@ import (
 	"github.com/itihey/tikuAdapter/pkg/logger"
 	"github.com/itihey/tikuAdapter/pkg/model"
 	"github.com/itihey/tikuAdapter/pkg/util"
-	"net/http"
-	"strings"
-	"sync"
 )
 
 // Search 搜题接口
@@ -47,6 +48,10 @@ func Search(c *gin.Context) {
 			&search.WannengClient{
 				Token:  c.Query("wannengToken"),
 				Enable: strings.Contains(c.Query("use"), "wanneng") || c.Query("use") == "",
+			},
+			&search.TikuhaiClient{
+				Enable: strings.Contains(c.Query("use"), "tikuhai") || c.Query("use") == "",
+				Token:  c.Query("tikuhaiToken"),
 			},
 			&search.EnncyClient{
 				Token:  c.Query("enncyToken"),

--- a/internal/search/tikuhai.go
+++ b/internal/search/tikuhai.go
@@ -1,0 +1,103 @@
+package search
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/go-resty/resty/v2"
+	"github.com/itihey/tikuAdapter/pkg/errors"
+	"github.com/itihey/tikuAdapter/pkg/logger"
+	"github.com/itihey/tikuAdapter/pkg/model"
+)
+
+type tikuhaiResponse struct {
+	Code int             `json:"code"`
+	Msg  string          `json:"msg"`
+	Data json.RawMessage `json:"data"`
+}
+
+type tikuhaiResult struct {
+	Answer []string `json:"answer"`
+	Num    int      `json:"num"`
+	Usenum int      `json:"usenum"`
+}
+
+// TikuhaiClient 题海题库客户端
+type TikuhaiClient struct {
+	Enable bool
+	Token  string
+}
+
+func (in *TikuhaiClient) getHTTPClient() *resty.Client {
+	return resty.New().
+		SetTimeout(5 * time.Second).
+		SetRetryCount(1).
+		SetRetryWaitTime(2 * time.Second).
+		AddRetryCondition(func(r *resty.Response, err error) bool {
+			return err != nil || r.StatusCode() >= 500
+		}).
+		AddRetryHook(func(r *resty.Response, err error) {
+			logger.SysError(fmt.Sprintf("题库海题库触发重试，状态码：%d，响应：%s", r.StatusCode(), r.String()))
+		}).
+		SetHeaders(map[string]string{
+			"Content-Type": "application/json",
+			"User-Agent":   "tikuhaiAdapter/0.1.0",
+			"v":            "0.1.0",
+		})
+}
+
+// SearchAnswer 搜索答案
+func (in *TikuhaiClient) SearchAnswer(req model.SearchRequest) (answer [][]string, err error) {
+	answer = make([][]string, 0)
+	if !in.Enable {
+		return answer, nil
+	}
+
+	// 构造请求参数
+	body := map[string]interface{}{
+		"question":     req.Question,
+		"options":      req.Options,
+		"type":         req.Type,
+		"key":          in.Token,
+		"questionData": "",
+	}
+
+	resp, err := in.getHTTPClient().R().
+		SetBody(body).
+		Post("https://api.tikuhai.com/search")
+
+	if err != nil || resp.StatusCode() != 200 {
+		return nil, errors.ErrTargetServerError
+	}
+
+	var res tikuhaiResponse
+
+	if err := json.Unmarshal(resp.Body(), &res); err != nil {
+
+		return nil, errors.ErrParserJSON
+	}
+
+	switch {
+	case res.Code == 200:
+		var result tikuhaiResult
+		if err := json.Unmarshal(res.Data, &result); err != nil {
+			return nil, errors.ErrParserJSON
+		}
+		if len(result.Answer) > 0 {
+			return [][]string{result.Answer}, nil
+		}
+		//200 有答案应该不会出现这种情况
+		return nil, errors.ErrTargetNoAnswer
+
+	case res.Code == -1 && strings.Contains(res.Msg, "有答案"):
+		return nil, errors.ErrTokenRequired
+
+	case res.Code == -1:
+		return nil, errors.ErrTargetNoAnswer
+
+	default:
+		return nil, errors.ErrTargetServerError
+	}
+}

--- a/internal/search/tikuhai.go
+++ b/internal/search/tikuhai.go
@@ -1,0 +1,102 @@
+package search
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/go-resty/resty/v2"
+	"github.com/itihey/tikuAdapter/pkg/errors"
+	"github.com/itihey/tikuAdapter/pkg/logger"
+	"github.com/itihey/tikuAdapter/pkg/model"
+)
+
+type TikuhaiResponse struct {
+	Code int             `json:"code"`
+	Msg  string          `json:"msg"`
+	Data json.RawMessage `json:"data"`
+}
+
+type TikuhaiResult struct {
+	Answer []string `json:"answer"`
+	Num    int      `json:"num"`
+	Usenum int      `json:"usenum"`
+}
+
+// TikuhaiClient 题海题库客户端
+type TikuhaiClient struct {
+	Enable bool
+	Token  string
+}
+
+func (in *TikuhaiClient) getHTTPClient() *resty.Client {
+	return resty.New().
+		SetTimeout(5 * time.Second).
+		SetRetryCount(1).
+		SetRetryWaitTime(2 * time.Second).
+		AddRetryCondition(func(r *resty.Response, err error) bool {
+			return err != nil || r.StatusCode() >= 500
+		}).
+		AddRetryHook(func(r *resty.Response, err error) {
+			logger.SysError(fmt.Sprintf("题库海题库触发重试，状态码：%d，响应：%s", r.StatusCode(), r.String()))
+		}).
+		SetHeaders(map[string]string{
+			"Content-Type": "application/json",
+			"User-Agent":   "tikuhaiAdapter/0.1.0",
+			"v":            "0.1.0",
+		})
+}
+
+func (in *TikuhaiClient) SearchAnswer(req model.SearchRequest) (answer [][]string, err error) {
+	answer = make([][]string, 0)
+	if !in.Enable {
+		return answer, nil
+	}
+
+	// 构造请求参数
+	body := map[string]interface{}{
+		"question":     req.Question,
+		"options":      req.Options,
+		"type":         req.Type,
+		"key":          in.Token,
+		"questionData": "",
+	}
+
+	resp, err := in.getHTTPClient().R().
+		SetBody(body).
+		Post("https://api.tikuhai.com/search")
+
+	if err != nil || resp.StatusCode() != 200 {
+		return nil, errors.ErrTargetServerError
+	}
+
+	var res TikuhaiResponse
+
+	if err := json.Unmarshal(resp.Body(), &res); err != nil {
+
+		return nil, errors.ErrParserJSON
+	}
+
+	switch {
+	case res.Code == 200:
+		var result TikuhaiResult
+		if err := json.Unmarshal(res.Data, &result); err != nil {
+			return nil, errors.ErrParserJSON
+		}
+		if len(result.Answer) > 0 {
+			return [][]string{result.Answer}, nil
+		}
+		//200 有答案应该不会出现这种情况
+		return nil, errors.ErrTargetNoAnswer
+
+	case res.Code == -1 && strings.Contains(res.Msg, "有答案"):
+		return nil, errors.ErrTokenRequired
+
+	case res.Code == -1:
+		return nil, errors.ErrTargetNoAnswer
+
+	default:
+		return nil, errors.ErrTargetServerError
+	}
+}

--- a/pkg/errors/error.go
+++ b/pkg/errors/error.go
@@ -11,4 +11,6 @@ var (
 	ErrTargetNoAnswer = errors.New("对方没有答案")
 	// ErrParserJSON 解析json错误
 	ErrParserJSON = errors.New("解析json错误")
+	// ErrTokenRequired 需要提供卡密
+	ErrTokenRequired = errors.New("需要提供卡密")
 )

--- a/test/search_test.go
+++ b/test/search_test.go
@@ -3,10 +3,11 @@ package test
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/itihey/tikuAdapter/internal/search"
-	"github.com/itihey/tikuAdapter/pkg/model"
 	"os"
 	"testing"
+
+	"github.com/itihey/tikuAdapter/internal/search"
+	"github.com/itihey/tikuAdapter/pkg/model"
 )
 
 func TestSearchIcodefClient_SearchAnswer(t *testing.T) {
@@ -135,4 +136,28 @@ func TestSearchLemonClient_SearchAnswer(t *testing.T) {
 	marshal, _ := json.Marshal(response)
 
 	fmt.Println("测试柠檬题库 成功搜题", string(marshal))
+}
+
+// TestSearchTikuhaiClient_SearchAnswer 测试题库海题库接口
+func TestSearchTikuhaiClient_SearchAnswer(t *testing.T) {
+	var client = search.TikuhaiClient{
+		Enable: true,
+		Token:  "",
+	}
+	testRequest := model.SearchRequest{
+		Question: "毛泽东思想形成的时代背景是( )",
+		Options:  []string{"帝国主义战争与无产阶级革命成为时代主题", "和平与发展成为时代主题", "世界多极化成为时代主题", "经济全球化成为时代主题"},
+		Type:     0,
+	}
+	//这道题付费题库里才有答案
+	// 调用被测试的方法
+	response, err := client.SearchAnswer(testRequest)
+
+	if err != nil {
+		fmt.Printf("请求题库海题库异常: %v", err)
+		return
+	}
+	marshal, _ := json.Marshal(response)
+
+	fmt.Println("测试题库海题库 成功搜题", string(marshal))
 }


### PR DESCRIPTION
自己在浏览器脚本中使用过的题库，挺好用就搬过来了
编程能力有限，自己改一点deepseek写一点
[题库海官方使用教程](https://flowus.cn/tikuhai/share/b514196b-527f-4812-8cf2-275d6ce917ff?code=DHMKK3)
教程中接口描述过于简陋，自己看教程中提及的脚本写过来的
本地测试可以正常获取答案
#52 